### PR TITLE
Fix for missing Battery tab in System Settings

### DIFF
--- a/1.0.0/EFI/OC/Config.plist
+++ b/1.0.0/EFI/OC/Config.plist
@@ -109,6 +109,36 @@
                     <key>TableSignature</key>
                     <data></data>
                 </dict>
+                <dict>
+                    <key>Base</key>
+                    <string></string>
+                    <key>BaseSkip</key>
+                    <integer>0</integer>
+                    <key>Comment</key>
+                    <string>Rename PM Profile (fix for Battery tab not showing in System Settings)</string>
+                    <key>Count</key>
+                    <integer>0</integer>
+                    <key>Enabled</key>
+                    <true/>
+                    <key>Find</key>
+                    <data>AAgJALIAAADw8Q==</data>
+                    <key>Limit</key>
+                    <integer>0</integer>
+                    <key>Mask</key>
+                    <data></data>
+                    <key>OemTableId</key>
+                    <data></data>
+                    <key>Replace</key>
+                    <data>AAIJALIAAADw8Q==</data>
+                    <key>ReplaceMask</key>
+                    <data></data>
+                    <key>Skip</key>
+                    <integer>0</integer>
+                    <key>TableLength</key>
+                    <integer>0</integer>
+                    <key>TableSignature</key>
+                    <data></data>
+                </dict>
             </array>
             <key>Quirks</key>
             <dict>


### PR DESCRIPTION
Rename the PM Profile in the FACP ACPI table from "8" (Tablet) to "2" (Laptop). This makes the battery tab appear again in System Settings on macOS Ventura and Sonoma.

macOS doesn't know what to do with a "8" (Tablet) PM Profile, so it treats the device like a desktop PC. Renaming the PM Profile to "2" (Laptop) in the FACP ACPI table makes the Battery tab appear again in the System Settings.